### PR TITLE
Automated docker container builds via actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  OWNEr: ${{ github.repository.owner }}
 
 jobs:
   build-and-push-image:
@@ -49,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER }}/${{ matrix.image }}
 
       - name: Build and Publish Docker Image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ vars.GITHUB_REPOSITORY_OWNER }}/${{ matrix.image }}
 
       - name: Build and Publish Docker Image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ github.event.repository.owner }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ github.event.repository.owner.name }}/${{ matrix.image }}
 
       - name: Build and Publish Docker Image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  OWNEr: ${{ github.repository.owner }}
+  OWNER: ${{ github.repository.owner }}
 
 jobs:
   build-and-push-image:
@@ -49,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository.owner }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
 
       - name: Build and Publish Docker Image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ vars.GITHUB_REPOSITORY_OWNER }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ github.repository.owner }}/${{ matrix.image }}
 
       - name: Build and Publish Docker Image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ github.event.repository.owner }}/${{ matrix.image }}
 
       - name: Build and Publish Docker Image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc


### PR DESCRIPTION
Creates two docker images: serge-api, and serge-webui available by the ghcr.io repo tied to this repository.
NOTE: Make sure to create a "release" branch where major releases get pulled into as this is what triggers the automated builds. Seems they changed how some GitHub variables worked so took a little trial and error.